### PR TITLE
Attribute key changes, fixes to support Scenario Outline

### DIFF
--- a/src/Formatter/JUnitFormatter.php
+++ b/src/Formatter/JUnitFormatter.php
@@ -190,10 +190,17 @@ class JUnitFormatter implements Formatter
     {
         $this->testcaseTimer->stop();
         $code = $event->getTestResult()->getResultCode();
+        $testResultString = array(
+            TestResult::PASSED    => 'passed',
+            TestResult::SKIPPED   => 'skipped',
+            TestResult::PENDING   => 'pending',
+            TestResult::FAILED    => 'failed',
+        );
 
         $this->testsuiteStats[$code]++;
 
-        $this->currentTestcase->addAttribute('timer', \round($this->testcaseTimer->getTime(), 3));
+        $this->currentTestcase->addAttribute('time', \round($this->testcaseTimer->getTime(), 3));
+        $this->currentTestcase->addAttribute('status', $testResultString[$code]);
     }
 
     /**
@@ -207,9 +214,9 @@ class JUnitFormatter implements Formatter
         $testsuite = $this->currentTestsuite;
         $testsuite->addAttribute('tests', array_sum($this->testsuiteStats));
         $testsuite->addAttribute('failures', $this->testsuiteStats[TestResult::FAILED]);
-        $testsuite->addAttribute('skips', $this->testsuiteStats[TestResult::SKIPPED]);
+        $testsuite->addAttribute('skipped', $this->testsuiteStats[TestResult::SKIPPED]);
         $testsuite->addAttribute('errors', $this->testsuiteStats[TestResult::PENDING]);
-        $testsuite->addAttribute('timer', \round($this->testsuiteTimer->getTime(), 3));
+        $testsuite->addAttribute('time', \round($this->testsuiteTimer->getTime(), 3));
     }
 
     /**

--- a/src/Formatter/JUnitFormatter.php
+++ b/src/Formatter/JUnitFormatter.php
@@ -5,6 +5,8 @@ namespace jarnaiz\JUnitFormatter\Formatter;
 use Behat\Testwork\Tester\Result\TestResult;
 use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Behat\EventDispatcher\Event\OutlineTested;
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Counter\Timer;
@@ -60,6 +62,11 @@ class JUnitFormatter implements Formatter
      * @var Timer
      */
     private $testcaseTimer;
+
+    /**
+     * @var String
+     */
+    private $currentOutlineTitle;
 
     /**
      * __construct
@@ -128,6 +135,9 @@ class JUnitFormatter implements Formatter
             FeatureTested::AFTER    => array('afterFeature', -50),
             ScenarioTested::BEFORE  => array('beforeScenario', -50),
             ScenarioTested::AFTER   => array('afterScenario', -50),
+            OutlineTested::BEFORE   => array('beforeOutline', -50),
+            ExampleTested::BEFORE  => array('beforeExample', -50),
+            ExampleTested::AFTER   => array('afterScenario', -50)
         );
     }
 
@@ -177,6 +187,33 @@ class JUnitFormatter implements Formatter
     {
         $this->currentTestcase = $this->currentTestsuite->addChild('testcase');
         $this->currentTestcase->addAttribute('name', $event->getScenario()->getTitle());
+
+        $this->testcaseTimer->start();
+    }
+
+    /**
+     * beforeOutline
+     *
+     * @param OutlineTested $event
+     *
+     * @return void
+     */
+    public function beforeOutline(OutlineTested $event)
+    {
+        $this->currentOutlineTitle = $event->getOutline()->getTitle();
+    }
+
+    /**
+     * beforeExample
+     *
+     * @param ScenarioTested $event
+     *
+     * @return void
+     */
+    public function beforeExample(ScenarioTested $event)
+    {
+        $this->currentTestcase = $this->currentTestsuite->addChild('testcase');
+        $this->currentTestcase->addAttribute('name', $this->currentOutlineTitle . ' Line #' . $event->getScenario()->getLine());
 
         $this->testcaseTimer->start();
     }


### PR DESCRIPTION
Hi there!

First off, thanks for the plugin :)

Changes made:
Added support for Scenario Outlines, outputs the Outline title & line number
I made some slight changes to match attribute names as defined here: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd

Let me know what you think!

Cheers,
Kash
