### PR TITLE
Added support for dealing with undefined sentences

### DIFF
--- a/src/Formatter/JUnitFormatter.php
+++ b/src/Formatter/JUnitFormatter.php
@@ -2,7 +2,7 @@
 
 namespace jarnaiz\JUnitFormatter\Formatter;
 
-use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Behat\Tester\Result\StepResult as TestResult;
 use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\EventDispatcher\Event\StepTested;
@@ -185,6 +185,7 @@ class JUnitFormatter implements Formatter
             TestResult::SKIPPED   => 0,
             TestResult::PENDING   => 0,
             TestResult::FAILED    => 0,
+            TestResult::UNDEFINED => 0,
         );
 
         $this->testsuiteTimer->start();
@@ -262,6 +263,7 @@ class JUnitFormatter implements Formatter
             TestResult::SKIPPED   => 'skipped',
             TestResult::PENDING   => 'pending',
             TestResult::FAILED    => 'failed',
+            TestResult::UNDEFINED => 'undefined',
         );
 
         $this->testsuiteStats[$code]++;


### PR DESCRIPTION
Hi

This PR fixes issues with the junit formatter if it stumbles on a scenario with undefined sentences like:
`PHP Notice:  Undefined offset: 30 in /var/www/vendor/jarnaiz/behat-junit-formatter/src/Formatter/JUnitFormatter.php on line 267`
`PHP Notice:  Undefined offset: 30 in /var/www/vendor/jarnaiz/behat-junit-formatter/src/Formatter/JUnitFormatter.php on line 270`
