### PR TITLE
Add file attribute to JUnit output

### DIFF
--- a/src/Formatter/JUnitFormatter.php
+++ b/src/Formatter/JUnitFormatter.php
@@ -71,16 +71,23 @@ class JUnitFormatter implements Formatter
     private $currentOutlineTitle;
 
     /**
+     * @var string
+     */
+    private $basepath;
+
+    /**
      * __construct
      *
-     * @param mixed $filename
-     * @param mixed $outputDir
+     * @param mixed  $filename
+     * @param mixed  $outputDir
+     * @param string $basepath
      */
-    public function __construct($filename, $outputDir)
+    public function __construct($filename, $outputDir, $basepath)
     {
         $this->printer        = new FileOutputPrinter($filename, $outputDir);
         $this->testsuiteTimer = new Timer();
         $this->testcaseTimer  = new Timer();
+        $this->basepath       = $basepath;
     }
 
     /**
@@ -179,6 +186,12 @@ class JUnitFormatter implements Formatter
 
         $this->currentTestsuite = $testsuite = $this->xml->addChild('testsuite');
         $testsuite->addAttribute('name', $feature->getTitle());
+        if ($feature->getFile() !== null) {
+            $testsuite->addAttribute(
+                'file',
+                str_replace($this->basepath . DIRECTORY_SEPARATOR, '', $feature->getFile())
+            );
+        }
 
         $this->testsuiteStats =  array(
             TestResult::PASSED    => 0,

--- a/src/JUnitFormatterExtension.php
+++ b/src/JUnitFormatterExtension.php
@@ -77,6 +77,7 @@ class JUnitFormatterExtension implements ExtensionInterface
 
         $definition->addArgument($filename);
         $definition->addArgument($outputDir);
+        $definition->addArgument($container->getParameter('paths.base'));
 
         $container->setDefinition('junit.formatter', $definition)
             ->addTag('output.formatter');


### PR DESCRIPTION
This PR adds a 'file' attribute, which is the relative path to the test file.

Example:

```xml
<testsuite name="Snippets generation and addition" file="features/snippets.feature" tests="2" failures="0" skipped="0" errors="0" time="8.762">
```

I can't find any written docs about the file attribute, but it seems to be pretty common.  I'm personally using this fork to [balance tests on CircleCI](https://circleci.com/blog/announcing-automatic-test-balancing/), which requires the `time` and `file` attributes to balance properly.